### PR TITLE
Fixes crash if no webpage URL from continueUserActivity 

### DIFF
--- a/mParticle-iterable/IterableMPHelper.m
+++ b/mParticle-iterable/IterableMPHelper.m
@@ -35,6 +35,9 @@ NSString *const IterableClickedURLKey = @"IterableClickedURLKey";
 
 +(BOOL) isIterableDeeplink:(NSURL *)webpageURL
 {
+    if (!webpageURL) {
+        return NO;
+    }
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:ITBL_DEEPLINK_IDENTIFIER options:0 error:NULL];
     NSString *urlString = webpageURL.absoluteString;
     NSTextCheckingResult *match = [regex firstMatchInString:urlString options:0 range:NSMakeRange(0, [urlString length])];


### PR DESCRIPTION
If your app is opened by`continueUserActivity` in the AppDelegate, but without a webpage url (eg. from a spotlight item / other activity) the Iterable Kit crashes in the NSRegularExpression call here, which can't take a nil string as a parameter.

Verified that the app continues to launch correctly with this nil check in place.