### PR TITLE
Fix Deprecated Deeplink API

### DIFF
--- a/mParticle-iterable/MPKitIterable.m
+++ b/mParticle-iterable/MPKitIterable.m
@@ -89,7 +89,7 @@ static IterableConfig *_customConfig = nil;
     };
 
     if (clickedURL != nil) {
-        [IterableAPI getAndTrackDeeplink:clickedURL callbackBlock:callbackBlock];
+        [IterableAPI handleUniversalLink:clickedURL];
     }
 
     MPKitExecStatus *execStatus = [[MPKitExecStatus alloc] initWithSDKCode:[MPKitIterable kitCode] returnCode:MPKitReturnCodeSuccess];


### PR DESCRIPTION
In Iterable SDK v6.3.2(https://github.com/Iterable/swift-sdk/releases/tag/6.3.2) getAndTrackDeeplink API is removed. 
<img width="689" alt="Screen Shot 2021-10-07 at 12 59 27 PM" src="https://user-images.githubusercontent.com/19657993/136431047-0b1c14b8-b1dc-415a-b278-2fd5d2638985.png">

