### PR TITLE
fix: Adds in new preference for userId primary identity

### DIFF
--- a/mParticle-iterable/MPKitIterable.h
+++ b/mParticle-iterable/MPKitIterable.h
@@ -11,17 +11,25 @@
 
 @interface MPKitIterable : NSObject <MPKitProtocol>
 
+
 @property (nonatomic, strong, nonnull) NSDictionary *configuration;
 @property (nonatomic, strong, nullable) NSDictionary *launchOptions;
 @property (nonatomic, unsafe_unretained, readonly) BOOL started;
 @property (nonatomic, strong, nullable) NSDictionary<NSString *, id> *userAttributes;
 @property (nonatomic, strong, nullable) NSArray<NSDictionary<NSString *, id> *> *userIdentities;
 @property (nonatomic, readwrite) BOOL mpidEnabled;
+//@property (nonatomic, readwrite) MPKitPrefersUserId prefersUserId;
 
 /**
  * Set a custom config to be used when initializing Iterable SDK
  * @param config `IterableConfig` instance with configuration data for Iterable SDK
  */
 + (void)setCustomConfig:(IterableConfig *_Nullable)config;
+
+/**
+ * Declare whether or not to prefer user id in API calls to Iterable. If `TRUE`, the kit will not
+ * set an email or create a placeholder.email address
+ */
++ (void)setPrefersUserId:(BOOL)prefers;
 
 @end


### PR DESCRIPTION
 ## Summary
 - Adds a new configuration to use the userId instead of creating a placeholder email for the mparticle identity.

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Tested locally to ensure a new user was created on mParticle with a userId instead of a placeholder email.