### PR TITLE
feat: Adds option for userId primary identity

### DIFF
--- a/mParticle-iterable/MPKitIterable.h
+++ b/mParticle-iterable/MPKitIterable.h
@@ -24,4 +24,11 @@
  */
 + (void)setCustomConfig:(IterableConfig *_Nullable)config;
 
+/**
+ * Declare whether or not to prefer user id in API calls to Iterable. If `TRUE`, the kit will not
+ * set an email or create a placeholder.email address
+ */
++ (void)setPrefersUserId:(BOOL)prefers;
++ (BOOL)prefersUserId;
+
 @end

--- a/mParticle-iterable/MPKitIterable.h
+++ b/mParticle-iterable/MPKitIterable.h
@@ -25,7 +25,7 @@
 + (void)setCustomConfig:(IterableConfig *_Nullable)config;
 
 /**
- * Declare whether or not to prefer user id in API calls to Iterable. If `TRUE`, the kit will not
+ * Declare whether or not to prefer user id in API calls to Iterable. If `YES`, the kit will not
  * set an email or create a placeholder.email address
  */
 + (void)setPrefersUserId:(BOOL)prefers;


### PR DESCRIPTION
 ## Summary
 - Adds a new configuration to use the userId instead of creating a placeholder email for the mparticle identity.

 ## Testing Plan
 - New functionality tested by Iterable in their PR here: https://github.com/mparticle-integrations/mparticle-apple-integration-iterable/pull/10

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-5124
