### PR TITLE
feat: adds data region config

### DIFF
--- a/mParticle-iterable/MPKitIterable.m
+++ b/mParticle-iterable/MPKitIterable.m
@@ -90,6 +90,7 @@ static BOOL _prefersUserId = NO;
         NSString *apnsProdIntegrationName = self.configuration[@"apnsProdIntegrationName"];
         NSString *apnsSandboxIntegrationName = self.configuration[@"apnsSandboxIntegrationName"];
         NSString *userIdField = self.configuration[@"userIdField"];
+        NSString *dataRegion = self.configuration[@"dataRegion"];
         self.mpidEnabled = [userIdField isEqualToString:@"mpid"];
 
         IterableConfig *config = _customConfig;
@@ -98,6 +99,7 @@ static BOOL _prefersUserId = NO;
         }
         config.pushIntegrationName = apnsProdIntegrationName;
         config.sandboxPushIntegrationName = apnsSandboxIntegrationName;
+        config.dataRegion = dataRegion;
         config.urlDelegate = self;
         
         [IterableAPI initializeWithApiKey:apiKey config:config];


### PR DESCRIPTION
 ## Summary
- update mParticle kit with new parameter, `dataRegion`,  for the `IterableConfig` class

 ## Testing Plan
 - Has not been tested. Coordinating with mParticle team to test.
 - dataRegion config has been release on the Swift SDK as of version 6.4.15
