### PR TITLE
feat: Improve Privacy Manifest support for iOS 17

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "Iterable/swift-sdk" ~> 6.5.1
-github "mparticle/mparticle-apple-sdk" ~> 8.0
+github "Iterable/swift-sdk" ~> 6.5.2
+github "mparticle/mparticle-apple-sdk" ~> 8.19

--- a/Package.swift
+++ b/Package.swift
@@ -14,20 +14,21 @@ let package = Package(
     dependencies: [
       .package(name: "mParticle-Apple-SDK",
                url: "https://github.com/mParticle/mparticle-apple-sdk",
-               .upToNextMajor(from: "8.0.0")),
+               .upToNextMajor(from: "8.19.0")),
       .package(name: "IterableSDK",
                url: "https://github.com/Iterable/swift-sdk",
-               .upToNextMajor(from: "6.5.1")),
+               .upToNextMajor(from: "6.5.2")),
     ],
     targets: [
         .target(
             name: "mParticle-Iterable",
             dependencies: [
-              .product(name: "mParticle-Apple-SDK", package: "mParticle-Apple-SDK"),
-              .product(name: "IterableSDK", package: "IterableSDK"),
+                .product(name: "mParticle-Apple-SDK", package: "mParticle-Apple-SDK"),
+                .product(name: "IterableSDK", package: "IterableSDK"),
             ],
             path: "mParticle-Iterable",
             exclude: ["Info.plist"],
+            resources: [.process("PrivacyInfo.xcprivacy")],
             publicHeadersPath: "."
         ),
     ]

--- a/mParticle-Iterable.podspec
+++ b/mParticle-Iterable.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |s|
 
     s.ios.deployment_target = "11.0"
     s.ios.source_files      = 'mParticle-Iterable/*.{h,m,mm}'
-    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
-    s.ios.dependency 'Iterable-iOS-SDK', '~> 6.5.1'
+    s.resource_bundles      = { 'mParticle-Iterable-Privacy' => ['mParticle-Iterable/PrivacyInfo.xcprivacy'] }
+    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.19'
+    s.ios.dependency 'Iterable-iOS-SDK', '~> 6.5'
 end

--- a/mParticle-iterable/PrivacyInfo.xcprivacy
+++ b/mParticle-iterable/PrivacyInfo.xcprivacy
@@ -2,17 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>NSPrivacyTracking</key>
-    <false/>
-    <key>NSPrivacyTrackingDomains</key>
-    <array/>
-    <key>NSPrivacyCollectedDataTypes</key>
-    <array>
-        <dict/>
-    </array>
-    <key>NSPrivacyAccessedAPITypes</key>
-    <array>
-        <dict/>
-    </array>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
 ## Summary
 - Fix parsing issue due to empty dict
 - Ensure manifest is included using all 3 package managers
 - Note the partner SDK doesn't properly include their privacy manifest when using CocoaPods yet, but our dependency should auto-update as soon as they do. I've already reported the issue here with recommendations: https://github.com/Iterable/swift-sdk/issues/750#issuecomment-2083504905)

 ## Testing Plan
 - [x] Was this tested locally? If not, explain why.
 - Confirmed in test apps using SPM, CocoaPods, and Carthage.

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-6401
