### PR TITLE
feat: Add IterableAppExtensions module to SPM support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,7 @@ let package = Package(
             dependencies: [
                 .product(name: "mParticle-Apple-SDK", package: "mParticle-Apple-SDK"),
                 .product(name: "IterableSDK", package: "IterableSDK"),
+                .product(name: "IterableAppExtensions", package: "IterableSDK")
             ],
             path: "mParticle-Iterable",
             exclude: ["Info.plist"],


### PR DESCRIPTION
 ## Summary
 - A customer is not able to utilize the IterableAppExtensions module since we don’t include it in our package.swift which is causing errors on compile when they install the Iterable kit via SPM

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - E2E tested

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-7217
