### PR TITLE
Fix Swift Package Manager integration issues

### DIFF
--- a/mParticle-iterable/MPKitIterable.h
+++ b/mParticle-iterable/MPKitIterable.h
@@ -28,6 +28,11 @@
  * @param config `IterableConfig` instance with configuration data for Iterable SDK
  */
 + (void)setCustomConfig:(IterableConfig *_Nullable)config;
+
+/**
+ * Set a custom config to be used when initializing Iterable SDK. To be used in cases where the compiler cannot resolve the IterableConfig type, such as with Swift Package Manager.
+ * @param config `IterableConfig` instance with configuration data for Iterable SDK
+ */
 + (void)setCustomConfigObject:(id _Nullable)config;
 
 /**

--- a/mParticle-iterable/MPKitIterable.h
+++ b/mParticle-iterable/MPKitIterable.h
@@ -28,6 +28,7 @@
  * @param config `IterableConfig` instance with configuration data for Iterable SDK
  */
 + (void)setCustomConfig:(IterableConfig *_Nullable)config;
++ (void)setCustomConfigObject:(id _Nullable)config;
 
 /**
  * Declare whether or not to prefer user id in API calls to Iterable. If `YES`, the kit will not

--- a/mParticle-iterable/MPKitIterable.m
+++ b/mParticle-iterable/MPKitIterable.m
@@ -29,6 +29,14 @@ static BOOL _prefersUserId = NO;
     _customUrlDelegate = config.urlDelegate;
 }
 
++ (void)setCustomConfigObject:(id _Nullable)config {
+	if ([config isKindOfClass:[IterableConfig class]]) {
+		[self setCustomConfig:(IterableConfig *)config];
+	} else if (config != nil) {
+		NSLog(@"[mParticle-Iterable] Warning: setCustomConfigObject called with an object of type %@, but expected IterableConfig. Ignoring.", NSStringFromClass([config class]));
+	}
+}
+
 + (BOOL)prefersUserId {
     return _prefersUserId;
 }

--- a/mParticle-iterable/MPKitIterable.m
+++ b/mParticle-iterable/MPKitIterable.m
@@ -33,7 +33,7 @@ static BOOL _prefersUserId = NO;
 	if ([config isKindOfClass:[IterableConfig class]]) {
 		[self setCustomConfig:(IterableConfig *)config];
 	} else if (config != nil) {
-		NSLog(@"[mParticle-Iterable] Warning: setCustomConfigObject called with an object of type %@, but expected IterableConfig. Ignoring.", NSStringFromClass([config class]));
+		NSLog(@"mParticle -> Error: setCustomConfigObject called with an object of type %@, but expected IterableConfig. Ignoring.", NSStringFromClass([config class]));
 	}
 }
 


### PR DESCRIPTION

```markdown
# Add setCustomConfigObject method for Swift Package Manager compatibility

## Summary
Add `setCustomConfigObject:` method to support Swift Package Manager integration

## Problem
When integrating the mParticle-Iterable kit with Swift Package Manager (SPM), Swift applications cannot use the existing `setCustomConfig:` method due to compilation issues. The Swift compiler fails to resolve the `IterableConfig` type reference in the bridging header, resulting in build errors like:

```
type 'MPKitIterable' has no member 'setCustomConfig'
```

This occurs because:
1. The `IterableConfig` class is defined in the Iterable Swift SDK
2. Swift Package Manager's module resolution doesn't always properly expose Objective-C headers that reference Swift types
3. The forward declaration `@class IterableConfig;` in `MPKitIterable.h` is insufficient for Swift compilation

## Solution
Added a new method `setCustomConfigObject:(id _Nullable)config` that:

1. **Uses generic `id` type**: Bypasses Swift's type resolution issues by accepting any object type
2. **Runtime type checking**: Validates the passed object is actually an `IterableConfig` instance using `isKindOfClass:`
3. **Safe casting**: Only performs the cast and calls the original method if type validation passes
4. **Error logging**: Provides clear feedback when incorrect types are passed
5. **Maintains backward compatibility**: The original `setCustomConfig:` method remains unchanged

## Technical Details

**Header Declaration:**
```objc
/**
 * Set a custom config to be used when initializing Iterable SDK. To be used in cases where the compiler cannot resolve the IterableConfig type, such as with Swift Package Manager.
 * @param config `IterableConfig` instance with configuration data for Iterable SDK
 */
+ (void)setCustomConfigObject:(id _Nullable)config;
```

**Implementation:**
```objc
+ (void)setCustomConfigObject:(id _Nullable)config {
    if ([config isKindOfClass:[IterableConfig class]]) {
        [self setCustomConfig:(IterableConfig *)config];
    } else if (config != nil) {
        NSLog(@"mParticle -> Error: setCustomConfigObject called with an object of type %@, but expected IterableConfig. Ignoring.", NSStringFromClass([config class]));
    }
}
```

## Usage in Swift
```swift
import IterableSDK
import mParticle_Iterable

let config = IterableConfig()
// This now works with SPM
MPKitIterable.setCustomConfigObject(config)
```

## Benefits
- ✅ **SPM Compatibility**: Resolves build issues with Swift Package Manager
- ✅ **Type Safety**: Runtime validation ensures only correct types are accepted
- ✅ **Backward Compatibility**: Existing code using `setCustomConfig:` continues to work
- ✅ **Clear Error Handling**: Developers get meaningful feedback for incorrect usage
- ✅ **Zero Performance Impact**: Only adds one runtime type check

## Testing
- [x] Builds successfully with Swift Package Manager
- [x] Runtime type checking works correctly
- [x] Error logging for incorrect types
- [x] Backward compatibility maintained

This change enables seamless integration of the mParticle-Iterable kit in modern iOS projects using Swift Package Manager while maintaining all existing functionality.
```