### PR TITLE
feat: Add no location target to Iterable kit

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,34 +3,56 @@
 
 import PackageDescription
 
+let noLocation = "-NoLocation"
+let mpIterable = "mParticle-Iterable"
+let mpIterableNoLocation = mpIterable + noLocation
+
+// MARK: - External Packages
+let mpSDK = "mParticle-Apple-SDK"
+let mpSDKNoLocation = mpSDK + noLocation
+let iterableSDK = "IterableSDK"
+
 let package = Package(
-    name: "mParticle-Iterable",
+    name: mpIterable,
     platforms: [ .iOS(.v11) ],
     products: [
         .library(
-            name: "mParticle-Iterable",
-            targets: ["mParticle-Iterable"]),
+            name: mpIterable,
+            targets: [mpIterable]),
     ],
     dependencies: [
-      .package(name: "mParticle-Apple-SDK",
+      .package(name: mpSDK,
                url: "https://github.com/mParticle/mparticle-apple-sdk",
                .upToNextMajor(from: "8.19.0")),
-      .package(name: "IterableSDK",
+      .package(name: iterableSDK,
                url: "https://github.com/Iterable/swift-sdk",
                .upToNextMajor(from: "6.5.2")),
     ],
     targets: [
         .target(
-            name: "mParticle-Iterable",
+            name: mpIterable,
             dependencies: [
-                .product(name: "mParticle-Apple-SDK", package: "mParticle-Apple-SDK"),
-                .product(name: "IterableSDK", package: "IterableSDK"),
-                .product(name: "IterableAppExtensions", package: "IterableSDK")
+                .product(name: mpSDK, package: mpSDK),
+                .product(name: iterableSDK, package: iterableSDK),
+                .product(name: "IterableAppExtensions", package: iterableSDK)
             ],
-            path: "mParticle-Iterable",
+            path: "mParticle-iterable",
             exclude: ["Info.plist"],
             resources: [.process("PrivacyInfo.xcprivacy")],
             publicHeadersPath: "."
+        ),
+        .target(
+            name: mpIterableNoLocation,
+            dependencies: [
+                .product(name: mpSDKNoLocation, package: mpSDK),
+                .product(name: iterableSDK, package: iterableSDK),
+                .product(name: "IterableAppExtensions", package: iterableSDK)
+            ],
+            path: "mParticle-iterable-NoLocation",
+            exclude: ["Info.plist"],
+            resources: [.process("PrivacyInfo.xcprivacy")],
+            publicHeadersPath: ".",
+            cSettings: [.define("MP_NO_LOCATION")]
         ),
     ]
 )

--- a/mParticle-Iterable.podspec
+++ b/mParticle-Iterable.podspec
@@ -12,8 +12,31 @@ Pod::Spec.new do |s|
     s.social_media_url = "https://twitter.com/mparticle"
 
     s.ios.deployment_target = "11.0"
-    s.ios.source_files      = 'mParticle-Iterable/*.{h,m,mm}'
     s.ios.resource_bundles  = { 'mParticle-Iterable-Privacy' => ['mParticle-Iterable/PrivacyInfo.xcprivacy'] }
-    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.19'
     s.ios.dependency 'Iterable-iOS-SDK', '~> 6.5'
+    
+    s.default_subspecs = "mParticleIterable"
+    
+        # ---- mParticleIterable ----
+    s.subspec 'mParticleIterable' do |ss|
+        ss.source_files = [
+          'mParticle-iterable/**/*.{h,m,mm,swift}'
+        ]
+
+        ss.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.37'
+    end
+
+    # ---- NoLocation ----
+    s.subspec 'mParticleIterableNoLocation' do |ss|
+        ss.pod_target_xcconfig = {
+            'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) MP_NO_LOCATION=1',
+            'SWIFT_ACTIVE_COMPILATION_CONDITIONS' => '$(inherited) MP_NO_LOCATION'
+        }
+
+        ss.source_files = [
+          'mParticle-iterable/**/*.{h,m,mm,swift}'
+        ]
+
+        ss.dependency 'mParticle-Apple-SDK/mParticleNoLocation', '~> 8.37'
+    end
 end

--- a/mParticle-iterable-NoLocation
+++ b/mParticle-iterable-NoLocation
@@ -1,0 +1,1 @@
+mParticle-iterable


### PR DESCRIPTION
 ## Summary
 - This PR introduces a NoLocation target for the Iterable kit through SPM and CocoaPods, allowing developers to integrate the kit without forcing a dependency on Core Location.

 ## Testing Plan
 - [X] Was this tested locally? If not, explain why.
 - E2E tested, verified events flowed in mP and Iterable when using both with location and no location targets

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://rokt.atlassian.net/browse/SDKE-308
