### PR TITLE
fix: Add Foundation import to IterableMPHelper.h file

### DIFF
--- a/mParticle-iterable/IterableMPHelper.h
+++ b/mParticle-iterable/IterableMPHelper.h
@@ -6,6 +6,7 @@
 //
 //
 
+#import <Foundation/Foundation.h>
 #ifndef IterableMPHelper_h
 #define IterableMPHelper_h
 


### PR DESCRIPTION
 ## Summary
 - Customer reported that they ran into a build error that looks like it needs to be fixed in the Iterable kit by adding import foundation to IterableMPHelper.h file. Here is a Gist of the build error: https://gist.github.com/tguidon/b732de9669b38be805ddfb90d12abf28

 ## Testing Plan
 - [ ] Was this tested locally? If not, explain why.
 - N/A

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://rokt.atlassian.net/browse/SDKE-862
